### PR TITLE
Avoid CTRR-like memory region

### DIFF
--- a/proxyclient/tools/chainload.py
+++ b/proxyclient/tools/chainload.py
@@ -55,6 +55,17 @@ bootargs_off = image_size
 bootargs_size = 0x4000
 image_size += bootargs_size
 
+# On M4/A18, iBoot adds a 48 KiB region ending at top_of_kernel_data
+# that secondary CPUs can't write to. This hack avoids using that region
+# by making the next m1n1's heap start above it
+protected_start = u.ba.top_of_kernel_data - 3 * 0x4000
+image_end = new_base + image_size
+if image_end > protected_start:
+    raise RuntimeError(
+        f"Chainload image 0x{new_base:x}..0x{image_end:x} overlaps "
+        f"protected range 0x{protected_start:x}..0x{u.ba.top_of_kernel_data:x}"
+    )
+
 print(f"Total region size: 0x{image_size:x} bytes")
 image_addr = u.malloc(image_size)
 
@@ -113,7 +124,7 @@ u.push_adt()
 print("Setting up bootargs...")
 tba = u.ba.copy()
 
-tba.top_of_kernel_data = new_base + image_size
+tba.top_of_kernel_data = u.ba.top_of_kernel_data
 
 if len(args.boot_args) > 0:
     boot_args = " ".join(args.boot_args)

--- a/src/chainload.c
+++ b/src/chainload.c
@@ -56,6 +56,16 @@ int chainload_image(void *image, size_t size, char **vars, size_t var_cnt)
     const size_t bootargs_size = SZ_16K;
     image_size += bootargs_size;
 
+    // On M4/A18, iBoot adds a 48 KiB region ending at top_of_kernel_data
+    // that secondary CPUs can't write to. This hack avoids using that region
+    // by making the next m1n1's heap start above it
+    u64 protected_start = cur_boot_args.top_of_kernel_data - 3 * SZ_16K;
+    if (new_base + image_size > protected_start) {
+        printf("chainload: Image 0x%lx..0x%lx overlaps protected range 0x%lx..0x%lx\n", new_base,
+               new_base + image_size, protected_start, cur_boot_args.top_of_kernel_data);
+        return -1;
+    }
+
     printf("chainload: Total image size: 0x%lx\n", image_size);
 
     size_t stub_size = _chainload_stub_end - _chainload_stub_start;
@@ -92,7 +102,7 @@ int chainload_image(void *image, size_t size, char **vars, size_t var_cnt)
     // Copy bootargs
     struct boot_args *new_boot_args = new_image + bootargs_off;
     *new_boot_args = cur_boot_args;
-    new_boot_args->top_of_kernel_data = new_base + image_size;
+    new_boot_args->top_of_kernel_data = cur_boot_args.top_of_kernel_data;
 
     // Copy chainload stub
     void *stub = new_image + image_size;

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -40,6 +40,9 @@
 
 #define MAX_MEM_REGIONS 32
 
+#define SYS_IMP_APL_CTRR_LOWER_EL1 sys_reg(3, 0, 11, 0, 0)
+#define SYS_IMP_APL_CTRR_UPPER_EL1 sys_reg(3, 0, 11, 0, 1)
+
 static void *dt = NULL;
 static int dt_bufsize = 0;
 static void *initrd_start = NULL;
@@ -373,6 +376,20 @@ static int dt_set_memory(void)
 
     u64 dram_min = cur_boot_args.phys_base;
     u64 dram_max = cur_boot_args.phys_base + cur_boot_args.mem_size;
+
+    // iBoot makes this CTRR range writable only from the boot CPU. Keep Linux from assigning its
+    // pages to secondary CPUs.
+    if (chip_id == T8132 || chip_id == T8140) {
+        u64 ctrr_start = ALIGN_DOWN(mrs(SYS_IMP_APL_CTRR_LOWER_EL1), get_page_size());
+        u64 ctrr_end = ALIGN_UP(mrs(SYS_IMP_APL_CTRR_UPPER_EL1) + SZ_4K, get_page_size());
+
+        if (ctrr_start < dram_min || ctrr_end <= ctrr_start || ctrr_end > dram_max)
+            bail("FDT: Invalid CTRR range 0x%lx..0x%lx\n", ctrr_start, ctrr_end);
+
+        printf("FDT: Reserving CTRR range 0x%lx..0x%lx\n", ctrr_start, ctrr_end);
+        if (fdt_add_mem_rsv(dt, ctrr_start, ctrr_end - ctrr_start))
+            bail("FDT: Could not reserve CTRR range\n");
+    }
 
     printf("FDT: DRAM at 0x%lx size 0x%lx\n", dram_base, dram_size);
     printf("FDT: Usable memory is 0x%lx..0x%lx (0x%lx)\n", dram_min, dram_max, dram_max - dram_min);


### PR DESCRIPTION
S3_0_C11_C0_0/1 are the lower and upper bounds for a region of memory that is RO for secondary CPUs, and RW for only the boot CPU. On all observed boots this region is 48KiB and ends at `top_of_kernel_data`. This causes Linux SMP start to randomly fail, and causes rare layout dependent issues with starting SMP on an XNU guest. These sysregs are locked so we have to work around this.

On Linux, we can avoid this region by reserving the memory. m1n1 uses a bump allocator, so the simplest fix is to start the allocator above this region. This gives m1n1 ~200KiB of headroom.